### PR TITLE
PADV-2323 - refactor: allow mobile app requests.

### DIFF
--- a/secure_cloudfront_video/edxapp_wrapper/backends/core_lib_o_v1.py
+++ b/secure_cloudfront_video/edxapp_wrapper/backends/core_lib_o_v1.py
@@ -1,0 +1,12 @@
+"""
+Backend for openedx.core.lib modules.
+"""
+
+from openedx.core.lib.mobile_utils import is_request_from_mobile_app
+
+
+def is_request_from_mobile_app_backend(request):
+    """
+    Backend function to check if the request is from a mobile app.
+    """
+    return is_request_from_mobile_app(request)

--- a/secure_cloudfront_video/edxapp_wrapper/core_lib.py
+++ b/secure_cloudfront_video/edxapp_wrapper/core_lib.py
@@ -1,0 +1,16 @@
+"""
+Backend definitions for openedx.core.lib modules.
+"""
+
+from importlib import import_module
+
+from django.conf import settings
+
+
+def is_request_from_mobile_app(request):
+    """
+    Check if the request is from a mobile app using the backend.
+    """
+    backend = import_module(settings.SCV_CORE_LIB_BACKEND)
+
+    return backend.is_request_from_mobile_app_backend(request)

--- a/secure_cloudfront_video/settings/common.py
+++ b/secure_cloudfront_video/settings/common.py
@@ -42,3 +42,4 @@ def plugin_settings(settings):
     settings.SCV_CLOUDFRONT_ID = ''
     settings.SCV_CLOUDFRONT_URL = ''
     settings.SCV_CLOUDFRONT_PRIVATE_SIGNING_KEY = ''
+    settings.SCV_CORE_LIB_BACKEND = 'secure_cloudfront_video.edxapp_wrapper.backends.core_lib_o_v1'  # pylint: disable=line-too-long


### PR DESCRIPTION
## Description:

This PR changes the authentication logic for the secure_cloudfront_video view. Now it accepts unauthenticated request only for mobile requests. Web requests still need the user to be authenticated.

## How to test:

- Install the plugin in the LMS and CMS containers.
- Get a secure cloud front video URL. Example in the ticket.
- Go to the endpoint authenticated and unauthenticated and check the behavior.
- Replicate mobile requests and check the behavior.

## Reviewers:

- [x] @anfbermudezme 