### PR TITLE
PADV-2323.1 - Remove unnecessary HOST and REFERER checks.

### DIFF
--- a/secure_cloudfront_video/views.py
+++ b/secure_cloudfront_video/views.py
@@ -38,12 +38,6 @@ def secure_cloudfront_video(request):
         log.info('Request is not authenticated or from mobile app.')
         raise Http404
 
-    meta = request.META
-
-    if not meta or meta.get('HTTP_HOST', '') not in meta.get('HTTP_REFERER', ''):
-        log.info('Request does not match HOST and/or REFERER.')
-        raise Http404
-
     key = request.GET.get('key', '')
     cloudfront_url = getattr(settings, 'SCV_CLOUDFRONT_URL', '')
     cloudfront_id = getattr(settings, 'SCV_CLOUDFRONT_ID', '')


### PR DESCRIPTION
## Description:

This PR removes HOST and HTTP_REFERER checks. Initially this endpoint was meant to be used on web only, however now we are integrating with mobile apps and mobile sends the request directly without an HTTP_REFERER, so this is going to be remove to meet mobile needs. This was also added to avoid direct usage of the API, however that it's also inconvenient for dev and final user usage.

## Reviewers:

- [x] @anfbermudezme 